### PR TITLE
Persist activities and registrations with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -47,4 +47,5 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+All data is persisted to a local SQLite database (`activities.db`), so
+activities and registrations survive server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import sqlite3
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,8 +20,8 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
+# Default activity data used to seed the database on first run
+default_activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -77,6 +78,104 @@ activities = {
     }
 }
 
+db_path = current_dir / "activities.db"
+
+
+def get_db_connection():
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def initialize_database():
+    with get_db_connection() as connection:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                name TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS registrations (
+                activity_name TEXT NOT NULL,
+                email TEXT NOT NULL,
+                PRIMARY KEY (activity_name, email),
+                FOREIGN KEY (activity_name) REFERENCES activities(name) ON DELETE CASCADE
+            );
+            """
+        )
+
+        existing_count = connection.execute(
+            "SELECT COUNT(*) AS count FROM activities"
+        ).fetchone()["count"]
+
+        if existing_count == 0:
+            for name, details in default_activities.items():
+                connection.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        name,
+                        details["description"],
+                        details["schedule"],
+                        details["max_participants"],
+                    ),
+                )
+
+                for email in details["participants"]:
+                    connection.execute(
+                        """
+                        INSERT INTO registrations (activity_name, email)
+                        VALUES (?, ?)
+                        """,
+                        (name, email),
+                    )
+
+        connection.commit()
+
+
+def load_activities():
+    activities = {}
+
+    with get_db_connection() as connection:
+        activity_rows = connection.execute(
+            """
+            SELECT name, description, schedule, max_participants
+            FROM activities
+            ORDER BY rowid
+            """
+        ).fetchall()
+
+        for row in activity_rows:
+            participant_rows = connection.execute(
+                """
+                SELECT email
+                FROM registrations
+                WHERE activity_name = ?
+                ORDER BY rowid
+                """,
+                (row["name"],),
+            ).fetchall()
+
+            activities[row["name"]] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [participant_row["email"] for participant_row in participant_rows],
+            }
+
+    return activities
+
+
+@app.on_event("startup")
+def startup():
+    initialize_database()
+
 
 @app.get("/")
 def root():
@@ -85,48 +184,79 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return load_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_db_connection() as connection:
+        activity = connection.execute(
+            "SELECT name FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        existing_registration = connection.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
+        ).fetchone()
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        if existing_registration is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is already signed up"
+            )
+
+        connection.execute(
+            """
+            INSERT INTO registrations (activity_name, email)
+            VALUES (?, ?)
+            """,
+            (activity_name, email),
         )
+        connection.commit()
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_db_connection() as connection:
+        activity = connection.execute(
+            "SELECT name FROM activities WHERE name = ?",
+            (activity_name,),
+        ).fetchone()
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        existing_registration = connection.execute(
+            """
+            SELECT 1
+            FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
+        ).fetchone()
+        if existing_registration is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity"
+            )
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        connection.execute(
+            """
+            DELETE FROM registrations
+            WHERE activity_name = ? AND email = ?
+            """,
+            (activity_name, email),
         )
+        connection.commit()
 
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite persistence
- initialize and seed DB on startup
- keep existing API routes and response shape
- update docs and ignore local .db files

## Why
Implements issue #9 so activity and registration data survive server restarts.